### PR TITLE
Let user script accept firstname, surname and password too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ script:
     - sleep 10
     - bin/initialize
     - bin/group public add
-    - bin/user public add
-    - bin/user public in public
+    - bin/user public firstname surname password add
+    - bin/user public firstname surname password in public
     - bin/search
     - yes | bin/clear
     - docker rm -f apacheds-test

--- a/bin/user
+++ b/bin/user
@@ -11,6 +11,12 @@ LDAPADD="ldapadd -v -h ${LDAPHOST} -p ${LDAPPORT} -x -D uid=admin,ou=system -w $
 LDAPMODIFY="ldapmodify -v -h ${LDAPHOST} -p ${LDAPPORT} -x -D uid=admin,ou=system -w ${LDAPPASS}"
 
 USER=$1
+USERFNAME=$2
+USERSNAME=$3
+USERPASSWORD=$4
+shift
+shift
+shift
 shift
 USERDN="uid=$USER,ou=Users,$LDAPDOMAIN"
 
@@ -26,12 +32,12 @@ objectClass: uidObject
 objectClass: inetOrgPerson
 objectClass: top
 cn: $USER
-givenName: $USER
-sn: $USER
+givenName: $USERFNAME
+sn: $USERSNAME
 uid: $USER
 mail: $USER@openmicroscopy.org
 ou: Users
-userpassword: ome
+userpassword: $USERPASSWORD
 EOF
 elif [ $1 = "in" ]; then
     shift
@@ -78,6 +84,7 @@ delete: owner
 owner: $USERDN
 EOF
 else
-    echo "huh?"
+    echo "wrong input values"
+    echo "./user add loginname firstname surname password add"
     exit 2
 fi

--- a/bin/user
+++ b/bin/user
@@ -85,6 +85,6 @@ owner: $USERDN
 EOF
 else
     echo "wrong input values"
-    echo "./user add loginname firstname surname password add"
+    echo "./user loginname firstname surname password add"
     exit 2
 fi


### PR DESCRIPTION
@joshmoore 

This PR tries to improve the ``user`` script so that it 


   1. accepts firstname, surname and password of the newly created ldap user, which will then appear in OMERO (tested on outreach)
   2. has an output which warns when something goes wrong (see the end of the script) and a suggestion about how to style the ``./user.... add`` command

Please feel free to reject, there is a following drawback in this suggestion:

  - I have added three ``shifts`` to the script to cater for the enriched input, which is fine for the ``add`` command. This causes the other commands (``./group`` for example) to now demand the input in the form of ``loginname firstname surname password`` as well, which is of course undesirable.


Any suggestions welcome. Thank you 